### PR TITLE
quic-go: replace dependency to Anapaya fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/caddyserver/caddy/v2 v2.9.0-beta.3
 	github.com/mholt/caddy-l4 v0.0.0-20240628163618-ca3e2f38f6e5
 	github.com/netsec-ethz/scion-apps v0.5.1-0.20250203095105-f70181af6440
-	github.com/scionproto-contrib/http-proxy v0.0.0-20250807112627-75f8cb44d797
+	github.com/scionproto-contrib/http-proxy v0.0.0-20250807143328-dc6fed80cec4
 	github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486
 	go.uber.org/zap v1.27.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,14 @@
 module github.com/scionproto-contrib/caddy-scion
 
-go 1.22.7
+go 1.23
 
-toolchain go1.22.10
+toolchain go1.23.11
 
 require (
 	github.com/caddyserver/caddy/v2 v2.9.0-beta.3
 	github.com/mholt/caddy-l4 v0.0.0-20240628163618-ca3e2f38f6e5
 	github.com/netsec-ethz/scion-apps v0.5.1-0.20250203095105-f70181af6440
-	github.com/scionproto-contrib/http-proxy v0.0.0-20250429151239-14abf6c18ab5
+	github.com/scionproto-contrib/http-proxy v0.0.0-20250807112627-75f8cb44d797
 	github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486
 	go.uber.org/zap v1.27.0
 )
@@ -108,7 +108,7 @@ require (
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.14.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
-	github.com/quic-go/quic-go v0.48.2 // indirect
+	github.com/quic-go/quic-go v0.50.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -154,7 +154,7 @@ require (
 	go.step.sm/linkedca v0.20.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/mock v0.4.0 // indirect
+	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap/exp v0.3.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
@@ -183,3 +183,5 @@ require (
 	modernc.org/strutil v1.2.0 // indirect
 	modernc.org/token v1.1.0 // indirect
 )
+
+replace github.com/quic-go/quic-go => github.com/Anapaya/quic-go v0.50.1-0.20250318085304-31c2831f6fe0

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/schollz/jsonstore v1.1.0 h1:WZBDjgezFS34CHI+myb4s8GGpir3UMpy7vWoCeO0n6E=
 github.com/schollz/jsonstore v1.1.0/go.mod h1:15c6+9guw8vDRyozGjN3FoILt0wpruJk9Pi66vjaZfg=
-github.com/scionproto-contrib/http-proxy v0.0.0-20250807112627-75f8cb44d797 h1:lPFzXpII0nuG+KUyfiEpGvGH45IT8mZHugoohUHFaS0=
-github.com/scionproto-contrib/http-proxy v0.0.0-20250807112627-75f8cb44d797/go.mod h1:YaE/C9Hi64p0GjyEOPv/56p8pNVpjudmCcLIZ9N8bcw=
+github.com/scionproto-contrib/http-proxy v0.0.0-20250807143328-dc6fed80cec4 h1:u3ygIugQsJpCO4ZfNA4r2WQy2wyPGOmtD4QGLkmNCH0=
+github.com/scionproto-contrib/http-proxy v0.0.0-20250807143328-dc6fed80cec4/go.mod h1:YaE/C9Hi64p0GjyEOPv/56p8pNVpjudmCcLIZ9N8bcw=
 github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486 h1:7hYIHKVxnrrvRvlHYX7cskTvXHCdb6HfFMYyzpZCPmk=
 github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486/go.mod h1:ZZdYvTNhrC3USJOP7XcMFFrwbyoYLGvTKb1L3aIzpxM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+github.com/Anapaya/quic-go v0.50.1-0.20250318085304-31c2831f6fe0 h1:HulUK7LnWNLAPyl+aD/9PlNM3Zv81n8CGc1FhBo70S8=
+github.com/Anapaya/quic-go v0.50.1-0.20250318085304-31c2831f6fe0/go.mod h1:Vim6OmUvlYdwBhXP9ZVrtGmCMWa3wEqhq3NgYrI8b4E=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -453,8 +455,6 @@ github.com/prometheus/procfs v0.14.0 h1:Lw4VdGGoKEZilJsayHf0B+9YgLGREba2C6xr+Fdf
 github.com/prometheus/procfs v0.14.0/go.mod h1:XL+Iwz8k8ZabyZfMFHPiilCniixqQarAy5Mu67pHlNQ=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
-github.com/quic-go/quic-go v0.48.2 h1:wsKXZPeGWpMpCGSWqOcqpW2wZYic/8T3aqiOID0/KWE=
-github.com/quic-go/quic-go v0.48.2/go.mod h1:yBgs3rWBOADpga7F+jJsb6Ybg1LSYiQvwWlLX+/6HMs=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -471,8 +471,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/schollz/jsonstore v1.1.0 h1:WZBDjgezFS34CHI+myb4s8GGpir3UMpy7vWoCeO0n6E=
 github.com/schollz/jsonstore v1.1.0/go.mod h1:15c6+9guw8vDRyozGjN3FoILt0wpruJk9Pi66vjaZfg=
-github.com/scionproto-contrib/http-proxy v0.0.0-20250429151239-14abf6c18ab5 h1:/nKbnp90gUY1OcczJ6KIklVQ1bq/Athb94MnZafa6zc=
-github.com/scionproto-contrib/http-proxy v0.0.0-20250429151239-14abf6c18ab5/go.mod h1:fxuXoCOIYWN/7ajNEUCezyQXKyVjbC0ILMgqFhXWfLg=
+github.com/scionproto-contrib/http-proxy v0.0.0-20250807112627-75f8cb44d797 h1:lPFzXpII0nuG+KUyfiEpGvGH45IT8mZHugoohUHFaS0=
+github.com/scionproto-contrib/http-proxy v0.0.0-20250807112627-75f8cb44d797/go.mod h1:YaE/C9Hi64p0GjyEOPv/56p8pNVpjudmCcLIZ9N8bcw=
 github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486 h1:7hYIHKVxnrrvRvlHYX7cskTvXHCdb6HfFMYyzpZCPmk=
 github.com/scionproto/scion v0.12.1-0.20241223103250-0b42cbc42486/go.mod h1:ZZdYvTNhrC3USJOP7XcMFFrwbyoYLGvTKb1L3aIzpxM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -645,8 +645,8 @@ go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwE
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
+go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -345,6 +345,12 @@ func testGetTargetOverIP(t *testing.T, useTLS bool) {
 func testGetTargetOverH3SCION(t *testing.T) {
 	roundTripper := shttp3.DefaultTransport
 	roundTripper.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	// XXX(JordiSubira): We cannot add the SCION quic version because the roundTripper tries to
+	// overwrite the tls.NextProtos with the quic-version https://github.com/Anapaya/quic-go/blob/release/v0.49.0/http3/transport.go#L325
+	//
+	// roundTripper.QUICConfig = &quic.Config{
+	// 	Versions: []quic.Version{0x5c10000f},
+	// }
 	defer roundTripper.Close()
 
 	client := &http.Client{


### PR DESCRIPTION
This PR replaces quic-go with Anapayas fork that adapts PMTUD to work when SCION is used underlay. This allows QUIC to work on certain network setups that require a MinSCIONInitialPacketSize <1200.